### PR TITLE
Implement Drop trait for DeviceState

### DIFF
--- a/src/device_state/linux/mod.rs
+++ b/src/device_state/linux/mod.rs
@@ -8,7 +8,7 @@ use std::os::raw::c_char;
 use std::ptr;
 use std::slice;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 /// Device state descriptor.
 pub struct DeviceState {
     display: *mut xlib::Display,
@@ -17,6 +17,14 @@ pub struct DeviceState {
 impl Default for DeviceState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Drop for DeviceState {
+    fn drop(&mut self) {
+        unsafe {
+            xlib::XCloseDisplay(self.display);
+        }
     }
 }
 


### PR DESCRIPTION
Because `Drop` trait is not defined for `DeviceState`, device_query could be panicked with following message when trying to get new display.
`Maximum number of clients reached...`

This PR is to fix that problem.
